### PR TITLE
robot-shop: Fix deployment API version for OCP 3.7

### DIFF
--- a/apps/robot-shop/manifest.yaml
+++ b/apps/robot-shop/manifest.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   name: robot-shop
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: cart
@@ -55,7 +55,7 @@ spec:
     service: cart
 
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: catalogue
@@ -108,7 +108,7 @@ spec:
     service: catalogue
 
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: dispatch
@@ -161,7 +161,7 @@ spec:
     service: dispatch
 
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: mongodb
@@ -364,7 +364,7 @@ spec:
     service: mysql
 
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: payment
@@ -418,7 +418,7 @@ spec:
     service: payment
 
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: rabbitmq
@@ -473,7 +473,7 @@ spec:
     service: rabbitmq
 
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: ratings
@@ -521,7 +521,7 @@ spec:
     service: ratings
 
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   labels:
@@ -588,7 +588,7 @@ spec:
     service: redis
 
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: shipping
@@ -637,7 +637,7 @@ spec:
     service: shipping
 
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: user
@@ -691,7 +691,7 @@ spec:
     service: user
 
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: web

--- a/apps/robot-shop/manifests/cart-deployment.yaml
+++ b/apps/robot-shop/manifests/cart-deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: cart

--- a/apps/robot-shop/manifests/catalogue-deployment.yaml
+++ b/apps/robot-shop/manifests/catalogue-deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: catalogue

--- a/apps/robot-shop/manifests/dispatch-deployment.yaml
+++ b/apps/robot-shop/manifests/dispatch-deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: dispatch

--- a/apps/robot-shop/manifests/mongodb-deployment.yaml
+++ b/apps/robot-shop/manifests/mongodb-deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: mongodb

--- a/apps/robot-shop/manifests/payment-deployment.yaml
+++ b/apps/robot-shop/manifests/payment-deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: payment

--- a/apps/robot-shop/manifests/rabbitmq-deployment.yaml
+++ b/apps/robot-shop/manifests/rabbitmq-deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: rabbitmq

--- a/apps/robot-shop/manifests/ratings-deployment.yaml
+++ b/apps/robot-shop/manifests/ratings-deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: ratings

--- a/apps/robot-shop/manifests/redis-deployment.yaml
+++ b/apps/robot-shop/manifests/redis-deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   labels:

--- a/apps/robot-shop/manifests/shipping-deployment.yaml
+++ b/apps/robot-shop/manifests/shipping-deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: shipping

--- a/apps/robot-shop/manifests/user-deployment.yaml
+++ b/apps/robot-shop/manifests/user-deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: user

--- a/apps/robot-shop/manifests/web-deployment.yaml
+++ b/apps/robot-shop/manifests/web-deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: web


### PR DESCRIPTION
The v1 deployment API on manifests is too new for OCP 3.7, this release was on v1beta1 for Deployments : 
https://docs.openshift.com/container-platform/3.7/rest_api/apis-apps/v1beta1.Deployment.html

This is the error out of k8s ansible module : 
```
TASK [robot-shop : Deploy robot-shop sample] **********************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to find exact match for apps.openshift.io/v1.Deployment by [kind, name, singularName, shortNames]"}

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=9    changed=2    unreachable=0    failed=1    skipped=17   rescued=0    ignored=0   

```