### PR TITLE
Update robot-shop to work on ROKS multi-az clusters

### DIFF
--- a/apps/robot-shop/README.md
+++ b/apps/robot-shop/README.md
@@ -28,6 +28,8 @@ You may edit individual definitions for different app resources. To create an up
 
 This will combine all YAMLs and create an updated `manifest.yaml`.
 
+If you need to install this demo app on Openshift 4 run `./build.sh 4` to create adjust deployments to use the `apps/v1` API instead of `apps/v1beta1`.
+
 ## Usage
 
 After successful installation, the app should be exposed at a facing URL. Wait for 4-5 minutes for all the services to start.

--- a/apps/robot-shop/build.sh
+++ b/apps/robot-shop/build.sh
@@ -2,3 +2,7 @@
 
 rm manifest.yaml
 for f in manifests/*.yaml; do (cat "${f}"; echo) >> manifest.yaml; done
+
+if [ "$1" == "4" ]; then
+  sed -i "s/v1beta1/v1/g" manifest.yaml
+fi

--- a/apps/robot-shop/manifest.yaml
+++ b/apps/robot-shop/manifest.yaml
@@ -206,7 +206,6 @@ metadata:
   name: mongodb-volume-claim
   namespace: robot-shop
 spec:
-  storageClassName: ""
   accessModes:
     - ReadWriteOnce
   resources:
@@ -230,58 +229,57 @@ spec:
     service: mongodb
 
 ---
-apiVersion: v1
-kind: DeploymentConfig
+apiVersion: apps/v1beta1
+kind: Deployment
 metadata:
   name: mysql
-#  labels:
-#    service: mysql
   namespace: robot-shop
 spec:
   replicas: 1
   selector:
     service: mysql
-  strategy:
-    type: Recreate
-    recreateParams:
-      post:
-        failurePolicy: ignore
-        execNewPod:
-          containerName: mysql
-          volumes:
-            - mysql-scripts-volume
-          command:
-          - /bin/sh
-          - -c
-          - sleep 120 && zcat /tmp/mysql-init-scripts/10-dump.sql.gz | /opt/rh/rh-mysql57/root/bin/mysql --force -h $MYSQL_SERVICE_HOST -u root -pR00t@123 -D $MYSQL_DATABASE -P 3306 && /opt/rh/rh-mysql57/root/bin/mysql -h $MYSQL_SERVICE_HOST -u root -pR00t@123 -P 3306 < /tmp/mysql-init-scripts/20-ratings.sql && sleep 60
-          env:
-          - name: MYSQL_USER
-            value: shipping
-          - name: MYSQL_PASSWORD
-            value: secret
-          - name: MYSQL_DATABASE
-            value: cities
+    matchLabels:
+      name: mysql
   template:
     metadata:
       labels:
         service: mysql
+        name: mysql
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
-      containers:
+      initContainers:
       - name: post-hook
-        imagePullPolicy: Always
-        image: docker.io/pranavgaikwad/robot-shop-mysql-post-hook:latest
         command:
         - /bin/sh
         - -c
-        - cp -r /tmp/post-scripts/* /tmp/mysql-init-scripts/ && sleep infinity
-        volumeMounts:
-        - mountPath: "/tmp/mysql-init-scripts/"
-          name: mysql-scripts-volume
-      - name: mysql
-        image: " "
+        - cp -r /tmp/post-scripts/* /var/lib/mysql/ && mkdir /var/lib/mysql/data
         imagePullPolicy: Always
+        image: docker.io/pranavgaikwad/robot-shop-mysql-post-hook:latest
+        volumeMounts:
+        - mountPath: "/var/lib/mysql/"
+          name: mysql-data-volume
+      containers:
+      - name: dataloader
+        image: registry.redhat.io/rhscl/mysql-57-rhel7:latest
+        imagePullPolicy: Always
+        volumeMounts:
+        - mountPath: "/var/lib/mysql/"
+          name: mysql-data-volume
+        command:
+        - /bin/sh
+        - -c
+        - sleep 120 && zcat /var/lib/mysql/10-dump.sql.gz | /opt/rh/rh-mysql57/root/bin/mysql --force -h $MYSQL_SERVICE_HOST -u root -pR00t@123 -D $MYSQL_DATABASE -P 3306 && /opt/rh/rh-mysql57/root/bin/mysql -h $MYSQL_SERVICE_HOST -u root -pR00t@123 -P 3306 < /var/lib/mysql/20-ratings.sql && sleep infinity
+        env:
+        - name: MYSQL_USER
+          value: shipping
+        - name: MYSQL_PASSWORD
+          value: secret
+        - name: MYSQL_DATABASE
+          value: cities
+      - name: mysql
+        imagePullPolicy: Always
+        image: registry.redhat.io/rhscl/mysql-57-rhel7:latest
         ports:
         - containerPort: 3306
         env:
@@ -301,29 +299,13 @@ spec:
             cpu: 100m
             memory: 400Mi
         volumeMounts:
-        - mountPath: "/var/lib/mysql/data"
+        - mountPath: "/var/lib/mysql"
           name: mysql-data-volume
-        - mountPath: "/tmp/mysql-init-scripts"
-          name: mysql-scripts-volume      
       restartPolicy: Always
       volumes:
       - name: mysql-data-volume
         persistentVolumeClaim:
           claimName: mysql-data-volume-claim
-      - name: mysql-scripts-volume
-        persistentVolumeClaim:
-          claimName: mysql-scripts-volume-claim
-  triggers:
-  - imageChangeParams:
-      automatic: true
-      containerNames:
-      - mysql
-      from:
-        kind: ImageStreamTag
-        name: mysql:5.7
-        namespace: openshift
-    type: ImageChange
-  - type: ConfigChange
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -331,20 +313,6 @@ metadata:
   name: mysql-data-volume-claim
   namespace: robot-shop
 spec:
-  storageClassName: ""
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 10Gi
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: mysql-scripts-volume-claim
-  namespace: robot-shop
-spec:
-  storageClassName: ""
   accessModes:
     - ReadWriteOnce
   resources:
@@ -569,7 +537,6 @@ metadata:
   namespace: robot-shop
   name: redis-volume-claim
 spec:
-  storageClassName: ""
   accessModes:
     - ReadWriteOnce
   resources:

--- a/apps/robot-shop/manifests/mongodb-deployment.yaml
+++ b/apps/robot-shop/manifests/mongodb-deployment.yaml
@@ -43,7 +43,6 @@ metadata:
   name: mongodb-volume-claim
   namespace: robot-shop
 spec:
-  storageClassName: ""
   accessModes:
     - ReadWriteOnce
   resources:

--- a/apps/robot-shop/manifests/mysql-deployment.yaml
+++ b/apps/robot-shop/manifests/mysql-deployment.yaml
@@ -1,56 +1,55 @@
 ---
-apiVersion: v1
-kind: DeploymentConfig
+apiVersion: apps/v1beta1
+kind: Deployment
 metadata:
   name: mysql
-#  labels:
-#    service: mysql
   namespace: robot-shop
 spec:
   replicas: 1
   selector:
     service: mysql
-  strategy:
-    type: Recreate
-    recreateParams:
-      post:
-        failurePolicy: ignore
-        execNewPod:
-          containerName: mysql
-          volumes:
-            - mysql-scripts-volume
-          command:
-          - /bin/sh
-          - -c
-          - sleep 120 && zcat /tmp/mysql-init-scripts/10-dump.sql.gz | /opt/rh/rh-mysql57/root/bin/mysql --force -h $MYSQL_SERVICE_HOST -u root -pR00t@123 -D $MYSQL_DATABASE -P 3306 && /opt/rh/rh-mysql57/root/bin/mysql -h $MYSQL_SERVICE_HOST -u root -pR00t@123 -P 3306 < /tmp/mysql-init-scripts/20-ratings.sql && sleep 60
-          env:
-          - name: MYSQL_USER
-            value: shipping
-          - name: MYSQL_PASSWORD
-            value: secret
-          - name: MYSQL_DATABASE
-            value: cities
+    matchLabels:
+      name: mysql
   template:
     metadata:
       labels:
         service: mysql
+        name: mysql
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
-      containers:
+      initContainers:
       - name: post-hook
-        imagePullPolicy: Always
-        image: docker.io/pranavgaikwad/robot-shop-mysql-post-hook:latest
         command:
         - /bin/sh
         - -c
-        - cp -r /tmp/post-scripts/* /tmp/mysql-init-scripts/ && sleep infinity
-        volumeMounts:
-        - mountPath: "/tmp/mysql-init-scripts/"
-          name: mysql-scripts-volume
-      - name: mysql
-        image: " "
+        - cp -r /tmp/post-scripts/* /var/lib/mysql/ && mkdir /var/lib/mysql/data
         imagePullPolicy: Always
+        image: docker.io/pranavgaikwad/robot-shop-mysql-post-hook:latest
+        volumeMounts:
+        - mountPath: "/var/lib/mysql/"
+          name: mysql-data-volume
+      containers:
+      - name: dataloader
+        image: registry.redhat.io/rhscl/mysql-57-rhel7:latest
+        imagePullPolicy: Always
+        volumeMounts:
+        - mountPath: "/var/lib/mysql/"
+          name: mysql-data-volume
+        command:
+        - /bin/sh
+        - -c
+        - sleep 120 && zcat /var/lib/mysql/10-dump.sql.gz | /opt/rh/rh-mysql57/root/bin/mysql --force -h $MYSQL_SERVICE_HOST -u root -pR00t@123 -D $MYSQL_DATABASE -P 3306 && /opt/rh/rh-mysql57/root/bin/mysql -h $MYSQL_SERVICE_HOST -u root -pR00t@123 -P 3306 < /var/lib/mysql/20-ratings.sql && sleep infinity
+        env:
+        - name: MYSQL_USER
+          value: shipping
+        - name: MYSQL_PASSWORD
+          value: secret
+        - name: MYSQL_DATABASE
+          value: cities
+      - name: mysql
+        imagePullPolicy: Always
+        image: registry.redhat.io/rhscl/mysql-57-rhel7:latest
         ports:
         - containerPort: 3306
         env:
@@ -70,29 +69,13 @@ spec:
             cpu: 100m
             memory: 400Mi
         volumeMounts:
-        - mountPath: "/var/lib/mysql/data"
+        - mountPath: "/var/lib/mysql"
           name: mysql-data-volume
-        - mountPath: "/tmp/mysql-init-scripts"
-          name: mysql-scripts-volume      
       restartPolicy: Always
       volumes:
       - name: mysql-data-volume
         persistentVolumeClaim:
           claimName: mysql-data-volume-claim
-      - name: mysql-scripts-volume
-        persistentVolumeClaim:
-          claimName: mysql-scripts-volume-claim
-  triggers:
-  - imageChangeParams:
-      automatic: true
-      containerNames:
-      - mysql
-      from:
-        kind: ImageStreamTag
-        name: mysql:5.7
-        namespace: openshift
-    type: ImageChange
-  - type: ConfigChange
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -100,20 +83,6 @@ metadata:
   name: mysql-data-volume-claim
   namespace: robot-shop
 spec:
-  storageClassName: ""
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 10Gi
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: mysql-scripts-volume-claim
-  namespace: robot-shop
-spec:
-  storageClassName: ""
   accessModes:
     - ReadWriteOnce
   resources:

--- a/apps/robot-shop/manifests/redis-deployment.yaml
+++ b/apps/robot-shop/manifests/redis-deployment.yaml
@@ -43,7 +43,6 @@ metadata:
   namespace: robot-shop
   name: redis-volume-claim
 spec:
-  storageClassName: ""
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
- Remove empty storageClassName parameters since they prevent auto provision of PVs
- Use a single volume for mysql. When multiple volumes are used it requires more deliberate PV setup so that they are all in the same availability zone, else the pod can't be scheduled.
- Stop using execNewPod so we can use RWO storage. ROKS block storage does not support RWX and ROKS file storage requires running containers as root or in a cluster without multiple availability zones.

 I also added a down and dirty flag to the build script so it will create a manifest.yaml usable on current OCP 4 releases.