### PR TITLE
fix call to sed for mac os

### DIFF
--- a/apps/robot-shop/build.sh
+++ b/apps/robot-shop/build.sh
@@ -4,5 +4,5 @@ rm manifest.yaml
 for f in manifests/*.yaml; do (cat "${f}"; echo) >> manifest.yaml; done
 
 if [ "$1" == "4" ]; then
-  sed -i "s/v1beta1/v1/g" manifest.yaml
+  sed -i -e "s/v1beta1/v1/g" manifest.yaml
 fi


### PR DESCRIPTION
Work around error on macos

```bash
./build.sh 4
sed: 1: "manifest.yaml": invalid command code m
```