### PR TITLE
fix nodejs imagestream tag

### DIFF
--- a/apps/parks-app/manifests/03.parks-app-build-config.yaml
+++ b/apps/parks-app/manifests/03.parks-app-build-config.yaml
@@ -28,7 +28,7 @@ spec:
       from:
         kind: ImageStreamTag
         namespace: openshift
-        name: nodejs:0.10
+        name: nodejs:10
   output:
     to:
       kind: ImageStreamTag


### PR DESCRIPTION
Tag 0.10 does not exist in nodejs imagestream, but 10 does.
