### PR TITLE
Don't fail if the directory already exists

### DIFF
--- a/apps/robot-shop/manifest.yaml
+++ b/apps/robot-shop/manifest.yaml
@@ -253,7 +253,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - cp -r /tmp/post-scripts/* /var/lib/mysql/ && mkdir /var/lib/mysql/data
+        - cp -r /tmp/post-scripts/* /var/lib/mysql/ && mkdir -p /var/lib/mysql/data
         imagePullPolicy: Always
         image: docker.io/pranavgaikwad/robot-shop-mysql-post-hook:latest
         volumeMounts:

--- a/apps/robot-shop/manifests/mysql-deployment.yaml
+++ b/apps/robot-shop/manifests/mysql-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - cp -r /tmp/post-scripts/* /var/lib/mysql/ && mkdir /var/lib/mysql/data
+        - cp -r /tmp/post-scripts/* /var/lib/mysql/ && mkdir -p /var/lib/mysql/data
         imagePullPolicy: Always
         image: docker.io/pranavgaikwad/robot-shop-mysql-post-hook:latest
         volumeMounts:


### PR DESCRIPTION
mysql fails to start after migration (or restart) because this directory already exists. The cmd needs to account for this.