### PR TITLE
Parks-app Use universal DockerImage for OCP 4.8+

### DIFF
--- a/apps/parks-app/manifests/03.parks-app-build-config.yaml
+++ b/apps/parks-app/manifests/03.parks-app-build-config.yaml
@@ -26,9 +26,8 @@ spec:
     type: Source
     sourceStrategy:
       from:
-        kind: ImageStreamTag
-        namespace: openshift
-        name: nodejs:10
+        kind: DockerImage
+        name: 'registry.redhat.io/ubi8/nodejs-10:latest'
   output:
     to:
       kind: ImageStreamTag


### PR DESCRIPTION
From 4.8, imagestreamtag is changed, and 4.9 does not have a supported nodejs-10 available in imagestream.
Similar to https://github.com/openshift/oadp-operator/pull/372