### PR TITLE
Multiarch mariadb

### DIFF
--- a/apps/todolist-mariadb-go/Dockerfile
+++ b/apps/todolist-mariadb-go/Dockerfile
@@ -1,19 +1,22 @@
-#FROM golang:1.17.8-alpine
-FROM ubi8
-USER root
-RUN dnf install -y golang vim
+FROM --platform=$BUILDPLATFORM golang:1.17.8-alpine AS builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ENV GOOS=${TARGETOS} \
+    GOARCH=${TARGETARCH} \
+    GOARM=${TARGETVARIANT}
+RUN mkdir /build
+WORKDIR /build
+COPY *.go .
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+RUN go mod tidy
+RUN CGO_ENABLED=0 go build -v -a -installsuffix cgo -o app
+
+FROM scratch
+COPY --from=builder /build/app /app
 COPY resources/ /resources/
 COPY index.html .
-COPY app .
-# dev
-#WORKDIR /go/src/github.com/weshayutin/todolist-mariadb-go
-#
-#COPY ./ .
-#
-#RUN chmod -R 777 ./
-#RUN go mod download
-
 EXPOSE 8000
-# use entrypoint for debug
-#ENTRYPOINT ["tail", "-f", "/dev/null"]
 CMD ["./app"]

--- a/apps/todolist-mariadb-go/Makefile
+++ b/apps/todolist-mariadb-go/Makefile
@@ -1,0 +1,34 @@
+REGISTRY ?= quay.io/mferrato
+IMAGE ?= todolist-mariadb-go
+VERSION ?= v1
+
+MANIFEST_IMG = $(REGISTRY)/$(IMAGE):$(VERSION)
+
+PLATFORMS ?= linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+
+ifeq ($(shell docker buildx inspect 2>/dev/null | awk '/Status/ { print $$2 }'), running)
+	BUILDX_ENABLED ?= true
+else
+	BUILDX_ENABLED ?= false
+endif
+
+define BUILDX_ERROR
+buildx not enabled, refusing to run this recipe
+endef
+
+manifest-buildx:
+ifneq ($(BUILDX_ENABLED), true)
+	$(error $(BUILDX_ERROR))
+endif
+	@echo "Running $@ target for platforms: $(PLATFORMS)"
+	docker buildx build \
+	--push \
+	--platform $(PLATFORMS) \
+	-t $(MANIFEST_IMG) \
+	.
+
+manifest-docker:
+	@echo "Running $@ target for platforms: $(PLATFORMS)"
+	MANIFEST="$(MANIFEST_IMG)" \
+	PLATFORM_LIST=$(PLATFORMS) \
+	./build-manifest.sh

--- a/apps/todolist-mariadb-go/build-manifest.sh
+++ b/apps/todolist-mariadb-go/build-manifest.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+if [[ -z $MANIFEST ]];
+then
+    echo "error: no manifest name provided"
+    exit 1
+fi
+
+if [[ -z $PLATFORM_LIST ]];
+then
+    PLATFORM_LIST="linux/amd64"
+fi
+
+IMAGE_LIST=""
+
+for PLATFORM in $(echo $PLATFORM_LIST | tr "," " ");
+do
+    echo "Building container image for platform: $PLATFORM"
+    ARCH="${PLATFORM#*/}"
+    IMAGE=$MANIFEST-$ARCH
+    docker build --push --platform=$PLATFORM -t $IMAGE .
+    IMAGE_LIST="$IMAGE_LIST $IMAGE"
+done
+
+echo "Creating manifest $MANIFEST from images: $IMAGE_LIST"
+docker manifest create -a $MANIFEST $IMAGE_LIST
+docker manifest push $MANIFEST

--- a/apps/todolist-mariadb-go/mysql-persistent-csi-template.yaml
+++ b/apps/todolist-mariadb-go/mysql-persistent-csi-template.yaml
@@ -152,7 +152,7 @@ items:
         spec:
           containers:
           - name: todolist
-            image:  quay.io/rhn_engineering_whayutin/todolist-mariadb-go:3
+            image:  quay.io/mferrato/todolist-mariadb-go:v1
             env:
               - name: foo
                 value: bar

--- a/apps/todolist-mariadb-go/mysql-persistent-template.yaml
+++ b/apps/todolist-mariadb-go/mysql-persistent-template.yaml
@@ -151,7 +151,7 @@ items:
         spec:
           containers:
           - name: todolist
-            image:  quay.io/rhn_engineering_whayutin/todolist-mariadb-go:3
+            image:  quay.io/mferrato/todolist-mariadb-go:v1
             env:
               - name: foo
                 value: bar


### PR DESCRIPTION
1. Enable building platform specific image in `Dockerfile`

2. Add a `Makefile` to automate multi-arch manifest image building
- add target to build the manifest using `docker buildx`
- add target to build the manifest using `docker manifest` (through `build-manifest.sh` script)

