### PR TITLE
Include exporter type in the pelorus values

### DIFF
--- a/apps/todolist-mongo-go/pelorus/values.yaml
+++ b/apps/todolist-mongo-go/pelorus/values.yaml
@@ -19,6 +19,7 @@ deployment:
 exporters:
   instances:
   - app_name: deploytime-exporter
+    exporter_type: deploytime
     source_context_dir: exporters/
     extraEnv:
     - name: APP_FILE
@@ -30,6 +31,7 @@ exporters:
     source_ref: master
     source_url: https://github.com/konveyor/pelorus.git
   - app_name: committime-exporter
+    exporter_type: committime
     source_context_dir: exporters/
     extraEnv:
     - name: APP_FILE


### PR DESCRIPTION
Exporter type is required to nicely check if the pod is ready
by selecting appropriate label:

$ oc wait pod -n pelorus --for=condition=Ready -l pelorus.konveyor.io/exporter-type=<type>