### PR TITLE
Add Pelorus config for the todolist-mongo-go to cover quay image case

### DIFF
--- a/apps/todolist-mongo-go/pelorus/periodic/quay_images_latest.yaml
+++ b/apps/todolist-mongo-go/pelorus/periodic/quay_images_latest.yaml
@@ -1,0 +1,50 @@
+# Config file for Pelorus project
+# https://github.com/konveyor/pelorus/
+
+# Deployment based on the Pelorus quay.io images
+# with the :latest flag, which are built after
+# every PR merge to Pelorus project
+
+openshift_prometheus_htpasswd_auth: internal:{SHA}+pvrmeQCmtWmYVOZ57uuITVghrM=
+openshift_prometheus_basic_auth_pass: changeme
+extra_prometheus_hosts:
+
+# Uncomment this if your cluster serves privately signed certificates
+# custom_ca: true
+
+deployment:
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/name: pelorus
+    app.kubernetes.io/version: v0.33.0
+
+exporters:
+  instances:
+  - app_name: deploytime-exporter
+    exporter_type: deploytime
+    image_tag: latest
+    extraEnv:
+    - name: LOG_LEVEL
+      value: DEBUG
+    - name: NAMESPACES
+      value: mongo-persistent
+
+  - app_name: committime-exporter
+    exporter_type: committime
+    image_tag: latest
+    extraEnv:
+    - name: LOG_LEVEL
+      value: DEBUG
+    - name: NAMESPACES
+      value: mongo-persistent
+
+#@  - app_name: failure-exporter
+#@    exporter_type: failure
+#@    image_tag: latest
+#@    env_from_secrets:
+#@    - github-secret
+#@    extraEnv:
+#@     - name: PROVIDER
+#@       value: github
+#@     - name: PROJECTS
+#@       value: konveyor/mig-demo-apps


### PR DESCRIPTION
New Pelorus config that will be used with e2e pelorus script scripts/run-pelorus-e2e-tests from the konveyor/pelorus project which covers case where deployment happens from the latest quay image rather than git source.

Note: The run-pelorus-e2e-tests will need to be updated to consume custom filenames for the var files.