### PR TITLE
Rename pelorus instance names to match e2e script requirements

### DIFF
--- a/apps/todolist-mongo-go/pelorus/periodic/different_deployment_methods.yaml
+++ b/apps/todolist-mongo-go/pelorus/periodic/different_deployment_methods.yaml
@@ -31,42 +31,42 @@ exporters:
     - name: NAMESPACES
       value: mongo-persistent
 
-  - app_name: deploytime-exporter-latest-custom-imagetag
+  - app_name: latest-custom-imagetag-deploytime-exporter
     exporter_type: deploytime
     image_tag: latest
     extraEnv:
     - name: NAMESPACES
       value: mongo-persistent
 
-  - app_name: committime-exporter-latest-custom-imagetag
+  - app_name: latest-custom-imagetag-committime-exporter
     exporter_type: committime
     image_tag: latest
     extraEnv:
     - name: NAMESPACES
       value: mongo-persistent
 
-  - app_name: deploytime-exporter-git-custom-url
+  - app_name: git-custom-url-deploytime-exporter
     exporter_type: deploytime
     source_url: https://github.com/konveyor/pelorus.git
     extraEnv:
     - name: NAMESPACES
       value: mongo-persistent
 
-  - app_name: committime-exporter-git-custom-url
+  - app_name: git-custom-url-committime-exporter
     exporter_type: committime
     source_url: https://github.com/konveyor/pelorus.git
     extraEnv:
     - name: NAMESPACES
       value: mongo-persistent
 
-  - app_name: deploytime-exporter-git-custom-source-ref
+  - app_name: git-custom-source-ref-deploytime-exporter
     exporter_type: deploytime
     source_ref: master
     extraEnv:
     - name: NAMESPACES
       value: mongo-persistent
 
-  - app_name: committime-exporter-git-custom-source-ref
+  - app_name: git-custom-source-ref-committime-exporter
     exporter_type: committime
     source_ref: master
     extraEnv:


### PR DESCRIPTION
Pelorus e2e script requires instance to have suffix '-exporter'