### PR TITLE
Add entries for various Pelorus committime exporter backends

### DIFF
--- a/apps/todolist-mongo-go/pelorus/values.yaml
+++ b/apps/todolist-mongo-go/pelorus/values.yaml
@@ -42,6 +42,45 @@ exporters:
       value: mongo-persistent
     source_ref: master
     source_url: https://github.com/konveyor/pelorus.git
+#gitlab-committime@  - app_name: gitlab-committime-exporter
+#gitlab-committime@    exporter_type: committime
+#gitlab-committime@    env_from_secrets:
+#gitlab-committime@    - gitlab-secret
+#gitlab-committime@    extraEnv:
+#gitlab-committime@    - name: LOG_LEVEL
+#gitlab-committime@      value: DEBUG
+#gitlab-committime@    - name: GIT_PROVIDER
+#gitlab-committime@      value: gitlab
+#gitlab-committime@    - name: NAMESPACES
+#gitlab-committime@      value: gitlab-binary
+#gitlab-committime@    source_ref: master
+#gitlab-committime@    source_url: https://github.com/konveyor/pelorus.git
+#bitbucket-committime@  - app_name: bitbucket-committime-exporter
+#bitbucket-committime@    exporter_type: committime
+#bitbucket-committime@    env_from_secrets:
+#bitbucket-committime@    - bitbucket-secret
+#bitbucket-committime@    extraEnv:
+#bitbucket-committime@    - name: LOG_LEVEL
+#bitbucket-committime@      value: DEBUG
+#bitbucket-committime@    - name: GIT_PROVIDER
+#bitbucket-committime@      value: bitbucket
+#bitbucket-committime@    - name: NAMESPACES
+#bitbucket-committime@      value: bitbucket-binary
+#bitbucket-committime@    source_ref: master
+#bitbucket-committime@    source_url: https://github.com/konveyor/pelorus.git
+#gitea-committime@  - app_name: gitea-committime-exporter
+#gitea-committime@    exporter_type: committime
+#gitea-committime@    env_from_secrets:
+#gitea-committime@    - gitea-secret
+#gitea-committime@    extraEnv:
+#gitea-committime@    - name: LOG_LEVEL
+#gitea-committime@      value: DEBUG
+#gitea-committime@    - name: GIT_PROVIDER
+#gitea-committime@      value: gitea
+#gitea-committime@    - name: NAMESPACES
+#gitea-committime@      value: gitea-binary
+#gitea-committime@    source_ref: master
+#gitea-committime@    source_url: https://github.com/konveyor/pelorus.git
 #@  - app_name: failure-exporter
 #@    exporter_type: failure
 #@    env_from_secrets:


### PR DESCRIPTION
For the e2e tests we use values.yaml to enable various exporters.

Adding additional commented out exporter instances to cover gitea, gitlab and bitbucket committime metrics allows to include tests using binary build annotations that are working with those exporters.

Each instance have different string for commenting it out that is specific to the backend and type of exporter. This allows to enable/disable various exporters during test execution using simple `sed "s/#${EXPORTER_TYPE}@//g" option.`

We will create separate namespace for each annotated build to easy cleanup process during e2e tests.