### PR TITLE
fix: Parks App

### DIFF
--- a/apps/parks-app/README.md
+++ b/apps/parks-app/README.md
@@ -4,7 +4,7 @@ A simple app to visualize locations of popular Historic Sites and National Parks
 
 ## Installation
 
-Login to your OpenShift cluster. 
+Login to your OpenShift cluster.
 
 To deploy:
 
@@ -18,16 +18,6 @@ To remove:
 ./destroy.sh
 ```
 
-`manifests` directory contains definitions for different resources required by the app. `manifest.yaml` is just a collection of all those definitions. 
-
-You may edit individual definitions for different app resources. To create an updated `manifest.yml` after updating individual resource definitions :
-
-```bash
-./build.sh
-```
-
-This will combine all YAMLs and create an updated `manifest.yaml`.
-
 ## Usage
 
 After successful installation, the app should be exposed at a public URL. Wait for 4-5 minutes for all the services to start.
@@ -36,6 +26,16 @@ To get the url to the frontend:
 
 ```bash
 oc get route -n parks-app restify -o go-template='{{ .spec.host }}{{ println }}'
+```
+
+## Development
+
+`manifests` directory contains definitions for different resources required by the app. `manifest.yaml` is just a collection of all those definitions.
+
+You may edit individual definitions for different app resources. To combine all YAMLs and create an updated `manifest.yaml`:
+
+```bash
+./build.sh
 ```
 
 If you read everything carefully, here's a cookie for you 🍪

--- a/apps/parks-app/build.sh
+++ b/apps/parks-app/build.sh
@@ -2,3 +2,4 @@
 
 rm manifest.yaml
 for f in manifests/*.yaml; do (cat "${f}"; echo) >> manifest.yaml; done
+sed -i '$ d' manifest.yaml

--- a/apps/parks-app/manifest.yaml
+++ b/apps/parks-app/manifest.yaml
@@ -1,12 +1,12 @@
 ---
-apiVersion: v1
 kind: ProjectRequest
+apiVersion: project.openshift.io/v1
 metadata:
   name: parks-app
 
 ---
 kind: ImageStream
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 metadata:
   name: restify
   namespace: parks-app
@@ -18,7 +18,7 @@ status:
 
 ---
 kind: BuildConfig
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 metadata:
   name: restify
   namespace: parks-app
@@ -44,9 +44,8 @@ spec:
     type: Source
     sourceStrategy:
       from:
-        kind: ImageStreamTag
-        namespace: openshift
-        name: nodejs:0.10
+        kind: DockerImage
+        name: 'registry.redhat.io/ubi8/nodejs-10:latest'
   output:
     to:
       kind: ImageStreamTag
@@ -55,10 +54,9 @@ spec:
 status:
   lastVersion: 0
 
-
 ---
 kind: DeploymentConfig
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 metadata:
   name: restify
   namespace: parks-app
@@ -83,7 +81,7 @@ spec:
     deploymentconfig: restify
   template:
     metadata:
-      creationTimestamp: 
+      creationTimestamp:
       labels:
         app: restify
         deploymentconfig: restify
@@ -114,7 +112,7 @@ status: {}
 
 ---
 kind: Route
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 metadata:
   name: restify
   namespace: parks-app
@@ -150,7 +148,7 @@ status:
 
 ---
 kind: DeploymentConfig
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 metadata:
   name: mongodb
   namespace: parks-app
@@ -158,15 +156,6 @@ spec:
   strategy:
     type: Recreate
   triggers:
-  - type: ImageChange
-    imageChangeParams:
-      automatic: true
-      containerNames:
-      - mongodb-container
-      from:
-        kind: ImageStreamTag
-        name: mongodb:latest
-        namespace: openshift
   - type: ConfigChange
   replicas: 1
   selector:
@@ -178,7 +167,7 @@ spec:
     spec:
       containers:
       - name: mongodb-container
-        image: " "
+        image: 'registry.redhat.io/rhscl/mongodb-36-rhel7:latest'
         ports:
         - containerPort: 27017
           protocol: TCP
@@ -222,8 +211,8 @@ status:
   loadBalancer: {}
 
 ---
-apiVersion: v1
 kind: PersistentVolumeClaim
+apiVersion: v1
 metadata:
   name: "mongodb-data-claim"
   namespace: parks-app
@@ -233,4 +222,3 @@ spec:
   resources:
     requests:
       storage: 10Gi
-

--- a/apps/parks-app/manifests/01.parks-app-namespace.yaml
+++ b/apps/parks-app/manifests/01.parks-app-namespace.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
 kind: ProjectRequest
+apiVersion: project.openshift.io/v1
 metadata:
   name: parks-app

--- a/apps/parks-app/manifests/02.parks-app-imagestream.yaml
+++ b/apps/parks-app/manifests/02.parks-app-imagestream.yaml
@@ -1,6 +1,6 @@
 ---
 kind: ImageStream
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 metadata:
   name: restify
   namespace: parks-app

--- a/apps/parks-app/manifests/03.parks-app-build-config.yaml
+++ b/apps/parks-app/manifests/03.parks-app-build-config.yaml
@@ -1,6 +1,6 @@
 ---
 kind: BuildConfig
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 metadata:
   name: restify
   namespace: parks-app
@@ -35,4 +35,3 @@ spec:
   resources: {}
 status:
   lastVersion: 0
-

--- a/apps/parks-app/manifests/front-end-route.yaml
+++ b/apps/parks-app/manifests/front-end-route.yaml
@@ -1,6 +1,6 @@
 ---
 kind: Route
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 metadata:
   name: restify
   namespace: parks-app

--- a/apps/parks-app/manifests/frontend-deployment.yaml
+++ b/apps/parks-app/manifests/frontend-deployment.yaml
@@ -1,6 +1,6 @@
 ---
 kind: DeploymentConfig
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 metadata:
   name: restify
   namespace: parks-app
@@ -25,7 +25,7 @@ spec:
     deploymentconfig: restify
   template:
     metadata:
-      creationTimestamp: 
+      creationTimestamp:
       labels:
         app: restify
         deploymentconfig: restify

--- a/apps/parks-app/manifests/mongo-deployment.yaml
+++ b/apps/parks-app/manifests/mongo-deployment.yaml
@@ -1,6 +1,6 @@
 ---
 kind: DeploymentConfig
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 metadata:
   name: mongodb
   namespace: parks-app
@@ -8,15 +8,6 @@ spec:
   strategy:
     type: Recreate
   triggers:
-  - type: ImageChange
-    imageChangeParams:
-      automatic: true
-      containerNames:
-      - mongodb-container
-      from:
-        kind: ImageStreamTag
-        name: mongodb:latest
-        namespace: openshift
   - type: ConfigChange
   replicas: 1
   selector:
@@ -28,7 +19,7 @@ spec:
     spec:
       containers:
       - name: mongodb-container
-        image: " "
+        image: 'registry.redhat.io/rhscl/mongodb-36-rhel7:latest'
         ports:
         - containerPort: 27017
           protocol: TCP

--- a/apps/parks-app/manifests/mongo-volume-claim.yaml
+++ b/apps/parks-app/manifests/mongo-volume-claim.yaml
@@ -1,6 +1,6 @@
 ---
-apiVersion: v1
 kind: PersistentVolumeClaim
+apiVersion: v1
 metadata:
   name: "mongodb-data-claim"
   namespace: parks-app


### PR DESCRIPTION
Mongo ImageStream seems to be not available anymore in OCP, so App was being deployed without the parks showing in the map.

Some other minor changes to avoid warnings from `oc` commands